### PR TITLE
Resolve pip installation issues

### DIFF
--- a/exercises/backend/requirements.txt
+++ b/exercises/backend/requirements.txt
@@ -8,7 +8,7 @@ fastapi==0.111.0
 fastapi-cli==0.0.4
 h11==0.14.0
 httpcore==1.0.5
-httptools==0.6.1
+httptools==0.6.4
 httpx==0.27.0
 idna==3.7
 Jinja2==3.1.4
@@ -30,6 +30,6 @@ typer==0.12.3
 typing_extensions==4.12.2
 ujson==5.10.0
 uvicorn==0.30.1
-uvloop==0.19.0
-watchfiles==0.22.0
+uvloop==0.21.0
+watchfiles==0.24.0
 websockets==12.0


### PR DESCRIPTION
I encountered an issue running `pip install -r requirements.txt` with the forked code. Changing these versions resolved my issue.

```
httptools==0.6.4
uvloop==0.21.0
watchfiles==0.24.0
```
I am on Python 3.13.0