### PR TITLE
Fix: Name updates don't reflect immediately on the frontend

### DIFF
--- a/exercises/frontend/src/app/page.tsx
+++ b/exercises/frontend/src/app/page.tsx
@@ -72,12 +72,8 @@ const NameEditor = (props: {
   } = props;
   const [firstName, setFirstName] = useState<string>(fetchedFirstName || "");
   const [lastName, setLastName] = useState<string>(fetchedLastName || "");
-  const [fullName, setFullName] = useState<string | null>(null);
 
-  useEffect(() => {
-    setFullName(`${firstName} ${lastName}`);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const fullName = `${fetchedFirstName || ""} ${fetchedLastName || ""}`;
 
   return (
     <div>


### PR DESCRIPTION
> For bugfixes

Fixes #1 

# Problem
- Full name does not display immediately after save and only updates on refresh because the fullName state is only set after initial load of the component via useEffect with an empty array for the second parameter.

# Changes
- To solve the issue, I removed the useEffect that initializes the fullName state and added a code that sets a variable fullName on rendering.

# Testing

*Before*:

https://github.com/user-attachments/assets/b4789a47-2fac-49d5-aaba-63150b96337d



*After*:

https://github.com/user-attachments/assets/c51280af-d425-45a5-94c0-943496e7c97f

